### PR TITLE
fixing default options

### DIFF
--- a/src/configuration.d.ts
+++ b/src/configuration.d.ts
@@ -20,7 +20,7 @@ import { LinkPrefetchOptions } from './modules/link-prefetch';
 import { OfflinePageOptions } from './modules/offline-page';
 
 export interface ServiceWorkerConfiguration {
-  documentCachingOptions: DocumentCachingOptions;
+  documentCachingOptions?: DocumentCachingOptions;
   assetCachingOptions?: AssetCachingOptions;
   linkPrefetchOptions?: LinkPrefetchOptions;
   offlinePageOptions?: OfflinePageOptions;

--- a/src/modules/core/index.ts
+++ b/src/modules/core/index.ts
@@ -30,7 +30,7 @@ declare global {
 const ampCachingModule = new AmpCachingModule();
 const documentCachingModule = new DocumentCachingModule();
 
-function init(config: ServiceWorkerConfiguration) {
+function init(config: ServiceWorkerConfiguration = {}) {
   ampCachingModule.init();
   let fallbackOfflinePageUrl;
   if (config.offlinePageOptions) {


### PR DESCRIPTION
- allows `AMP_SW` to be initialized like `AMP_SW.init()` instead of `AMP_SW.init({})`