### PR TITLE
Fix reference to the required attribute for prefetching

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,8 +7,8 @@ The project aims to bring network resiliency and other network related optimizat
 Core use cases:
 - Cache AMP scripts with a `stale-while-revalidate` strategy for a longer duration that http-headers.
 - Cache valid visited AMP documents, and serve only in case of flaky network conditions.
-- Cache assets which are critical to a page with a given stategy.
-- Prefetch outgoing linksfrom an AMP page.
+- Cache assets which are critical to a page with a given strategy.
+- Prefetch outgoing links from an AMP page.
 - Cache an offline page in order to show when a user navigates to a page which was previously not visited.
 
 

--- a/src/modules/link-prefetch/README.md
+++ b/src/modules/link-prefetch/README.md
@@ -24,5 +24,5 @@ AMP_SW.init({
 })
 ```
 
-In additions with this the outgoing links that you want to be precached need to have the attribute `data-prefetch`.
-e.g. `<a href='/' data-prefetch>`
+In additions with this the outgoing links that you want to be precached need to have the attribute `data-rel="prefetch"`.
+e.g. `<a href='/' data-rel='prefetch'>`


### PR DESCRIPTION
The docs for `link-prefetch` says to add `data-prefetch` attribute. However, the `amp-install-serviceworker` component actually looks for `data-rel=prefetch`:

https://github.com/ampproject/amphtml/blob/0937333cb3f4d1b09bd41f86db565c2dcda7ed3a/extensions/amp-install-serviceworker/0.1/amp-install-serviceworker.js#L389

This fixes that, and while also fixing a couple typos.