### PR TITLE
fixing valid amp doc regexp and increasing unversion files lifeline

### DIFF
--- a/src/modules/amp-caching/index.ts
+++ b/src/modules/amp-caching/index.ts
@@ -75,7 +75,7 @@ export class AmpCachingModule implements AmpSwModule {
         cacheName: UNVERSIONED_CACHE_NAME,
         plugins: [
           new Plugin({
-            maxAgeSeconds: 24 * 60 * 60, // 1 day
+            maxAgeSeconds: 7 * 24 * 60 * 60, // 7 days
           }),
         ],
       }),

--- a/src/modules/document-caching/AmpDocumentCachablePlugin.ts
+++ b/src/modules/document-caching/AmpDocumentCachablePlugin.ts
@@ -33,7 +33,7 @@ export default class AmpDocumentCachablePlugin extends Plugin {
       try {
         const responseBody = await clonedResponse.text();
         // Check if the response is AMP HTML page, only then cache it.
-        if (/<html (⚡|amphtml)/.test(responseBody)) {
+        if (/<html.*(\s)(⚡️|amp)(\s.*>|>)/.test(responseBody)) {
           return response;
         }
       } catch (e) {

--- a/src/modules/document-caching/AmpDocumentCachablePlugin.ts
+++ b/src/modules/document-caching/AmpDocumentCachablePlugin.ts
@@ -33,7 +33,7 @@ export default class AmpDocumentCachablePlugin extends Plugin {
       try {
         const responseBody = await clonedResponse.text();
         // Check if the response is AMP HTML page, only then cache it.
-        if (/<html.*(\s)(⚡️|amp)(\s.*>|>)/.test(responseBody)) {
+        if (/<html.*(\s)(⚡|amp)(\s.*>|>).*/.test(responseBody)) {
           return response;
         }
       } catch (e) {

--- a/src/modules/document-caching/AmpDocumentCachablePlugin.ts
+++ b/src/modules/document-caching/AmpDocumentCachablePlugin.ts
@@ -33,7 +33,7 @@ export default class AmpDocumentCachablePlugin extends Plugin {
       try {
         const responseBody = await clonedResponse.text();
         // Check if the response is AMP HTML page, only then cache it.
-        if (/<html.*(\s)(⚡|amp)(\s.*>|>).*/.test(responseBody)) {
+        if (/<html\s[^>]*(⚡|amp)[^>]*>/.test(responseBody)) {
           return response;
         }
       } catch (e) {

--- a/test/modules/amp-caching/amp-caching-test.js
+++ b/test/modules/amp-caching/amp-caching-test.js
@@ -119,12 +119,12 @@ describe('AMP caching module', function() {
         expect(responseText).to.be.equal('dummy response');
       });
 
-      it('should expire cached Response after 2 days', async () => {
+      it('should expire cached Response after 8 days', async () => {
         const responseText = await addPreDatedResponseToCache(
           cacheName,
           scriptURL,
           driver,
-          2 * 24 * 60 * 60 * 1000,
+          8 * 24 * 60 * 60 * 1000,
         );
         expect(responseText).to.not.be.equal('dummy response');
       });

--- a/test/modules/document-caching/document-caching-test.js
+++ b/test/modules/document-caching/document-caching-test.js
@@ -154,7 +154,7 @@ describe('Document caching module', function() {
   // TODO: figure out how to test navigation preloading
 
   describe('cacheAMPDocument', function() {
-    it('should be not cache the current page URL if its not AMP page', async () => {
+    it('should not cache the current page URL if its not AMP page', async () => {
       const generatedSW = await buildSW({}, '/test/dist/amp-sw.js');
       await writeFile(serviceWorkerPath, generatedSW);
       await driver.get('http://localhost:6881/test/index.html');
@@ -175,7 +175,7 @@ describe('Document caching module', function() {
       );
       expect(cachedData).to.be.null;
     });
-    it('should be cache the current page URL if its not AMP page', async () => {
+    it('should cache the current page URL if its AMP page', async () => {
       const generatedSW = await buildSW({}, '/test/dist/amp-sw.js');
       await writeFile(serviceWorkerPath, generatedSW);
       await driver.get('http://localhost:6881/test/alternate.amp.html');


### PR DESCRIPTION
- Fixes #13 
- Adds a better regexp for checking valid amp pages