### PR TITLE
Adds purgeOnQuotaError on static assets

### DIFF
--- a/src/modules/asset-caching/index.ts
+++ b/src/modules/asset-caching/index.ts
@@ -31,6 +31,7 @@ export type AssetCachingOptions = Array<{
   regexp: RegExp;
   cachingStrategy: 'NETWORK_FIRST' | 'CACHE_FIRST' | 'STALE_WHILE_REVALIDATE';
   denyList?: Array<RegExp>;
+  purgeOnQuotaError?: boolean;
 }>;
 
 class AssetCachingPlugin extends Plugin {
@@ -74,12 +75,17 @@ export class AssetCachingAmpModule implements AmpSwModule {
   init(assetCachingOptions: AssetCachingOptions) {
     assetCachingOptions.forEach(assetCachingOption => {
       let cachingStrategy = null;
+      let purgeOnQuotaError = true;
+      if (assetCachingOption.purgeOnQuotaError !== undefined) {
+        purgeOnQuotaError = assetCachingOption.purgeOnQuotaError;
+      }
       const cachingConfig = {
         cacheName,
         plugins: [
           new AssetCachingPlugin({
             maxEntries: 25,
             denyList: assetCachingOption.denyList,
+            purgeOnQuotaError,
           }),
         ],
       };


### PR DESCRIPTION
Fixes #8 
- Will purge static assets if hits a quota error.
- Configurable with `purgeOnQuotaError` key, accepting a boolean.