### PR TITLE
udpate SizePlugin version & add support for bot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampproject/amp-sw",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1554,6 +1554,24 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
+    "axios": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+          "dev": true
+        }
+      }
+    },
     "babel-extract-comments": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/babel-extract-comments/-/babel-extract-comments-1.0.0.tgz",
@@ -2187,6 +2205,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/chunkd/-/chunkd-1.0.0.tgz",
       "integrity": "sha512-xx3Pb5VF9QaqCotolyZ1ywFBgyuJmu6+9dLiqBxgelEse9Xsr3yUlpoX3O4Oh11M00GT2kYMsRByTKIMJW2Lkg==",
+      "dev": true
+    },
+    "ci-env": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/ci-env/-/ci-env-1.10.0.tgz",
+      "integrity": "sha512-kXGriGO7hW/uxDviPtUUehSG301RudEHUXNhAHeM5JM7iOSb6+tpXh+YqhcfxdCECvtfMNq0J7laOxAV3NsDng==",
       "dev": true
     },
     "ci-info": {
@@ -3842,6 +3866,32 @@
       "requires": {
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "dev": true,
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
       }
     },
     "for-in": {
@@ -8746,17 +8796,19 @@
       }
     },
     "size-plugin": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/size-plugin/-/size-plugin-1.1.1.tgz",
-      "integrity": "sha512-32k0gfNVkP8bHYtA1zmgsko6kKRuB97l480rmnUxQe9jHabYSx29psB2eFXb9dlqQww0T1E/cqV2D1fXaFnjfQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/size-plugin/-/size-plugin-2.0.0.tgz",
+      "integrity": "sha512-0ww2iVo8RjZtafpuJocP7P+ueYLCepEwvw5kmcNQUqdYmjmpOre179PockiFapm0CinTNGEHsE8KI7OFZLHRUg==",
       "dev": true,
       "requires": {
-        "chalk": "^2.4.1",
+        "axios": "^0.19.0",
+        "chalk": "^2.4.2",
+        "ci-env": "^1.9.0",
         "escape-string-regexp": "^1.0.5",
-        "glob": "^7.1.2",
-        "gzip-size": "^5.0.0",
+        "glob": "^7.1.4",
+        "gzip-size": "^5.1.1",
         "minimatch": "^3.0.4",
-        "pretty-bytes": "^5.1.0",
+        "pretty-bytes": "^5.3.0",
         "util.promisify": "^1.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "selenium-assistant": "6.0.0",
     "serve-handler": "5.0.7",
     "sinon": "7.3.2",
-    "size-plugin": "1.1.1",
+    "size-plugin": "^2.0.0",
     "terser-webpack-plugin": "1.2.0",
     "ts-loader": "5.3.2",
     "typescript": "3.1.2",

--- a/size-plugin.json
+++ b/size-plugin.json
@@ -1,0 +1,1 @@
+[{"timestamp":1566503201980,"files":[{"filename":"amp-sw.js","previous":0,"size":8150,"diff":8150},{"filename":"optional-modules.js","previous":0,"size":1561,"diff":1561},{"filename":"service-worker-remover.js","previous":0,"size":427,"diff":427}]}]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -85,7 +85,7 @@ module.exports = (options = {}) => {
       ]
     },
     plugins: [
-      new SizePlugin(),
+      new SizePlugin({publish:true}),
       new CleanWebpackPlugin([buildPath]),
       new ReplaceInFileWebpackPlugin([{
         dir: 'dist',


### PR DESCRIPTION
👋
I noticed `amp-sw` is using [size-plugin](https://github.com/GoogleChromeLabs/size-plugin) .

I have created a [bot](https://github.com/kuldeepkeshwar/size-plugin-bot), which works with  [size-plugin](https://github.com/GoogleChromeLabs/size-plugin) and comments the sizes of the assets and the changes since the last build into the relevant PR

I have done the required configuration in pr (updating `size-plugin@2.0.0` & turn on `publish` flag)

Action item: 
- install [bot](https://github.com/kuldeepkeshwar/size-plugin-bot)